### PR TITLE
login component for demo user created & added on login/sign up pages

### DIFF
--- a/client/src/components/LoginWithDemoUser/LogInWithDemoUser.tsx
+++ b/client/src/components/LoginWithDemoUser/LogInWithDemoUser.tsx
@@ -1,0 +1,41 @@
+import { Box, Button, CircularProgress, TextField } from '@material-ui/core';
+import { useState } from 'react';
+import { useAuth } from '../../context/useAuthContext';
+import { useSnackBar } from '../../context/useSnackbarContext';
+import login from '../../helpers/APICalls/login';
+
+export default function LogInWithDemoUser(): JSX.Element {
+  const { updateLoginContext } = useAuth();
+  const { updateSnackBarMessage } = useSnackBar();
+  const [isSubmitting, setSubmitting] = useState(false);
+
+  const autoLogin = () => {
+    const { email, password } = {
+      email: 'demo.user@hatchways.io',
+      password: 'demoPassword',
+    };
+    setSubmitting(true);
+
+    login(email, password).then((data) => {
+      if (data.error) {
+        setSubmitting(false);
+        updateSnackBarMessage(data.error.message);
+      } else if (data.success) {
+        updateLoginContext(data.success);
+      } else {
+        setSubmitting(false);
+        // should not get here from backend but this catch is for an unknown issue
+        console.error({ data });
+        updateSnackBarMessage('An unexpected error occurred. Please try again');
+      }
+    });
+  };
+
+  return (
+    <Box>
+      <Button type="button" size="large" variant="contained" color="primary" onClick={autoLogin}>
+        {isSubmitting ? <CircularProgress style={{ color: 'white' }} /> : 'Login For Demo'}
+      </Button>
+    </Box>
+  );
+}

--- a/client/src/pages/Login/LoginForm/LoginForm.tsx
+++ b/client/src/pages/Login/LoginForm/LoginForm.tsx
@@ -89,7 +89,7 @@ export default function Login({ handleSubmit }: Props): JSX.Element {
             <Button type="submit" size="large" variant="contained" color="primary" className={classes.submit}>
               {isSubmitting ? <CircularProgress style={{ color: 'white' }} /> : 'Login'}
             </Button>
-            <LogInWithDemoUser></LogInWithDemoUser>
+            <LogInWithDemoUser />
           </Box>
           <div style={{ height: 95 }} />
         </form>

--- a/client/src/pages/Login/LoginForm/LoginForm.tsx
+++ b/client/src/pages/Login/LoginForm/LoginForm.tsx
@@ -6,6 +6,7 @@ import * as Yup from 'yup';
 import Typography from '@material-ui/core/Typography';
 import useStyles from './useStyles';
 import { CircularProgress } from '@material-ui/core';
+import LogInWithDemoUser from '../../../components/LoginWithDemoUser/LogInWithDemoUser';
 
 interface Props {
   handleSubmit: (
@@ -88,6 +89,7 @@ export default function Login({ handleSubmit }: Props): JSX.Element {
             <Button type="submit" size="large" variant="contained" color="primary" className={classes.submit}>
               {isSubmitting ? <CircularProgress style={{ color: 'white' }} /> : 'Login'}
             </Button>
+            <LogInWithDemoUser></LogInWithDemoUser>
           </Box>
           <div style={{ height: 95 }} />
         </form>

--- a/client/src/pages/SignUp/SignUpForm/SignUpForm.tsx
+++ b/client/src/pages/SignUp/SignUpForm/SignUpForm.tsx
@@ -6,6 +6,7 @@ import * as Yup from 'yup';
 import Typography from '@material-ui/core/Typography';
 import useStyles from './useStyles';
 import { CircularProgress } from '@material-ui/core';
+import LogInWithDemoUser from '../../../components/LoginWithDemoUser/LogInWithDemoUser';
 
 interface Props {
   handleSubmit: (
@@ -111,6 +112,7 @@ const SignUpForm = ({ handleSubmit }: Props): JSX.Element => {
             <Button type="submit" size="large" variant="contained" color="primary" className={classes.submit}>
               {isSubmitting ? <CircularProgress style={{ color: 'white' }} /> : 'Create'}
             </Button>
+            <LogInWithDemoUser></LogInWithDemoUser>
           </Box>
         </form>
       )}

--- a/client/src/pages/SignUp/SignUpForm/SignUpForm.tsx
+++ b/client/src/pages/SignUp/SignUpForm/SignUpForm.tsx
@@ -112,7 +112,7 @@ const SignUpForm = ({ handleSubmit }: Props): JSX.Element => {
             <Button type="submit" size="large" variant="contained" color="primary" className={classes.submit}>
               {isSubmitting ? <CircularProgress style={{ color: 'white' }} /> : 'Create'}
             </Button>
-            <LogInWithDemoUser></LogInWithDemoUser>
+            <LogInWithDemoUser />
           </Box>
         </form>
       )}


### PR DESCRIPTION
### What this PR does (required):
- a new component has been created to allow the user to log in without having to manually enter their credentials (for demo purposes).

### Screenshots / Videos (required):
![image](https://user-images.githubusercontent.com/62568487/120626453-30cc7480-c452-11eb-89ec-1a346db1fe5e.png)
![image](https://user-images.githubusercontent.com/62568487/120626495-3c1fa000-c452-11eb-964f-eadf8ddefac0.png)




### Any information needed to test this feature (required):
- click the "Login for demo" button

### Any issues with the current functionality (optional):
- since the login and password are hardcoded, I manually created a demo user first on the database (through the sign up page). |  is this the best way to proceed?
