### PR TITLE
added ebay scrapper

### DIFF
--- a/server/services/ebayScraperService.js
+++ b/server/services/ebayScraperService.js
@@ -1,0 +1,47 @@
+const puppeteer = require("puppeteer");
+
+exports.getProductDetail = async (productUrl) => {
+  if (productUrl) {
+    try {
+      const browser = await puppeteer.launch({ headless: true });
+      const page = await browser.newPage();
+      await page.goto(productUrl, { waitUntil: "domcontentloaded" });
+
+      const productData = await page.evaluate(() => {
+        //product description
+        // uncomment if we decide to include post description later
+        // const postBody = document.querySelector("#postingbody").innerText.replaceAll('\n', ' ');
+
+        //product price
+        let price = "unavailable";
+
+        try {
+          price = document.getElementById("prcIsum").innerText;
+        } catch (error) {
+          console.log("Price not availble for this product");
+          throw new Error(error);
+        }
+        //product title
+        const title = document.getElementsByClassName("it-ttl")[0].innerText;
+
+        // product image
+        const image = document.getElementById("icImg").src;
+
+        return {
+          productTitle: title,
+          productImage: image,
+          productPrice: price,
+        };
+      });
+
+      await browser.close();
+      productData.url = productUrl;
+      Object.freeze(productData);
+      return productData;
+    } catch (error) {
+      throw new Error(error);
+    }
+  } else {
+    throw new Error("Product url not provided");
+  }
+};


### PR DESCRIPTION
### What this PR does (required):
- added scrapper for ebay

Screenshots / Videos (required):

    nothing here

Any information needed to test this feature (required):

    const { getProductDetail } = require('../services/amazonScrapingService');
    getProductDetail(
    "ebay item link"
    ).then((data) => console.log(data));

Any issues with the current functionality (optional):
none 