### PR TITLE
integration for FE lists and product

### DIFF
--- a/client/src/components/AddList/AddList.tsx
+++ b/client/src/components/AddList/AddList.tsx
@@ -1,0 +1,86 @@
+import Button from '@material-ui/core/Button';
+import TextField from '@material-ui/core/TextField';
+import Box from '@material-ui/core/Box';
+import { Formik } from 'formik';
+import Typography from '@material-ui/core/Typography';
+import useStyles from './useStyles';
+import { CircularProgress } from '@material-ui/core';
+import Container from '@material-ui/core/Container';
+import { Icon, DialogActions, Grid, CssBaseline, Paper, IconButton } from '@material-ui/core';
+import { addNewList } from '../../helpers/APICalls/lists';
+
+interface Props {
+  handleSubmit: () => void;
+}
+
+export default function AddList({ onClose }: any): JSX.Element {
+  const classes = useStyles();
+
+  const handleSubmit = (data: any) => {
+    addNewList(data);
+    onClose();
+  };
+
+  const renderModalContent = () => {
+    return (
+      <Container component="main" style={{ minWidth: '670px' }} maxWidth="xs" className="bg-secondary">
+        <Formik
+          initialValues={{
+            name: '',
+          }}
+          onSubmit={handleSubmit}
+        >
+          {({ handleSubmit, handleChange, values, touched, errors, isSubmitting }) => (
+            <form onSubmit={handleSubmit} className={classes.form} noValidate>
+              <TextField
+                id="name"
+                label={<Typography className={classes.label}>Name</Typography>}
+                fullWidth
+                margin="normal"
+                InputLabelProps={{
+                  shrink: true,
+                }}
+                InputProps={{
+                  classes: { input: classes.inputs },
+                }}
+                name="name"
+                autoComplete="name"
+                autoFocus
+                value={values.name}
+                onChange={handleChange}
+              />
+              <Box textAlign="center">
+                <Button type="submit" size="large" variant="contained" color="primary" className={classes.submit}>
+                  {isSubmitting ? <CircularProgress style={{ color: 'white' }} /> : 'Add'}
+                </Button>
+              </Box>
+            </form>
+          )}
+        </Formik>
+      </Container>
+    );
+  };
+
+  return (
+    <Grid container component="main">
+      <CssBaseline />
+      <Box className={classes.modalBoxContainer}>
+        <Paper>
+          <Grid className={classes.closeSignUpButton}>
+            <IconButton onClick={onClose}>
+              <Icon>close</Icon>
+            </IconButton>
+          </Grid>
+          <Grid container>
+            <Grid item xs>
+              <Typography className={classes.welcome} component="h1" variant="h5">
+                Add New List
+              </Typography>
+            </Grid>
+          </Grid>
+          {renderModalContent()}
+        </Paper>
+      </Box>
+    </Grid>
+  );
+}

--- a/client/src/components/AddList/AddList.tsx
+++ b/client/src/components/AddList/AddList.tsx
@@ -8,6 +8,7 @@ import { CircularProgress } from '@material-ui/core';
 import Container from '@material-ui/core/Container';
 import { Icon, DialogActions, Grid, CssBaseline, Paper, IconButton } from '@material-ui/core';
 import { addNewList } from '../../helpers/APICalls/lists';
+import * as Yup from 'yup';
 
 interface Props {
   handleSubmit: () => void;
@@ -21,6 +22,10 @@ export default function AddList({ onClose }: any): JSX.Element {
     onClose();
   };
 
+  const nameSchema = Yup.object().shape({
+    name: Yup.string().min(2, 'Too Short!').max(50, 'Too Long!').required('Required'),
+  });
+
   const renderModalContent = () => {
     return (
       <Container component="main" style={{ minWidth: '670px' }} maxWidth="xs" className="bg-secondary">
@@ -29,33 +34,40 @@ export default function AddList({ onClose }: any): JSX.Element {
             name: '',
           }}
           onSubmit={handleSubmit}
+          validationSchema={nameSchema}
         >
-          {({ handleSubmit, handleChange, values, touched, errors, isSubmitting }) => (
-            <form onSubmit={handleSubmit} className={classes.form} noValidate>
-              <TextField
-                id="name"
-                label={<Typography className={classes.label}>Name</Typography>}
-                fullWidth
-                margin="normal"
-                InputLabelProps={{
-                  shrink: true,
-                }}
-                InputProps={{
-                  classes: { input: classes.inputs },
-                }}
-                name="name"
-                autoComplete="name"
-                autoFocus
-                value={values.name}
-                onChange={handleChange}
-              />
-              <Box textAlign="center">
-                <Button type="submit" size="large" variant="contained" color="primary" className={classes.submit}>
-                  {isSubmitting ? <CircularProgress style={{ color: 'white' }} /> : 'Add'}
-                </Button>
-              </Box>
-            </form>
-          )}
+          {({ handleSubmit, handleChange, values, touched, errors, isSubmitting }) => {
+            const err: any = errors.name && touched.name ? true : false;
+            const helperText: string = err ? 'Please Provide a name' : '';
+            return (
+              <form onSubmit={handleSubmit} className={classes.form}>
+                <TextField
+                  id="name"
+                  label={<Typography className={classes.label}>Name</Typography>}
+                  fullWidth
+                  margin="normal"
+                  InputLabelProps={{
+                    shrink: true,
+                  }}
+                  InputProps={{
+                    classes: { input: classes.inputs },
+                  }}
+                  name="name"
+                  autoComplete="name"
+                  autoFocus
+                  value={values.name}
+                  onChange={handleChange}
+                  error={err}
+                  helperText={helperText}
+                />
+                <Box textAlign="center">
+                  <Button type="submit" size="large" variant="contained" color="primary" className={classes.submit}>
+                    {isSubmitting ? <CircularProgress style={{ color: 'white' }} /> : 'Add'}
+                  </Button>
+                </Box>
+              </form>
+            );
+          }}
         </Formik>
       </Container>
     );

--- a/client/src/components/AddList/useStyles.ts
+++ b/client/src/components/AddList/useStyles.ts
@@ -1,0 +1,48 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme) => ({
+  form: {
+    width: '100%', // Fix IE 11 issue.
+    marginTop: theme.spacing(1),
+  },
+  label: {
+    fontSize: 15,
+    paddingLeft: '5px',
+    fontWeight: 'bolder',
+  },
+  inputs: {
+    marginTop: '.8rem',
+    height: '2rem',
+    padding: '5px',
+    border: 'none',
+    minHeight: '40px',
+    lineHeight: '60px',
+    textAlign: 'center',
+    borderRadius: '6px',
+  },
+  submit: {
+    margin: theme.spacing(3, 2, 2),
+    padding: 10,
+    width: 160,
+    height: 56,
+    marginTop: 49,
+    fontSize: 16,
+    fontWeight: 'bold',
+  },
+  welcome: {
+    fontSize: 26,
+    paddingBottom: 20,
+    color: '#000000',
+    fontWeight: 700,
+    fontFamily: "'Open Sans'",
+    textAlign: 'center',
+  },
+  closeSignUpButton: {
+    textAlign: 'right',
+  },
+  modalBoxContainer: {
+    margin: theme.spacing(10, 'auto'),
+  },
+}));
+
+export default useStyles;

--- a/client/src/components/AddProduct/AddProduct.tsx
+++ b/client/src/components/AddProduct/AddProduct.tsx
@@ -58,17 +58,18 @@ const AddProduct = (): JSX.Element => {
       pictureUrl: productDetails.productImage,
     } as unknown as Product;
 
-    createProduct(newProduct, listID).then((data: ProductApiData) => {
-      if (data.error) {
-        updateSnackBarMessage(data.error.message);
-      } else if (data.success) {
-        setShowAddProductModal(false);
-        setShowPreviewModal(false);
-        updateSnackBarMessage(data.success.message);
-      } else {
-        console.error({ data });
-        updateSnackBarMessage('An unexpected error occurred. Please try again');
+    createProduct(newProduct, listID).then((data: Product) => {
+      if (!data) {
+        updateSnackBarMessage('PRoduct could not be created');
       }
+      // } else if (data.success) {
+      setShowAddProductModal(false);
+      setShowPreviewModal(false);
+      updateSnackBarMessage('Product added succesfully');
+      // } else {
+      //   console.error({ data });
+      //   updateSnackBarMessage('An unexpected error occurred. Please try again');
+      // }
     });
   };
 

--- a/client/src/helpers/APICalls/lists.ts
+++ b/client/src/helpers/APICalls/lists.ts
@@ -1,7 +1,13 @@
 import { AuthApiData } from '../../interface/AuthApiData';
 import { FetchOptions } from '../../interface/FetchOptions';
+import { List } from '../../interface/List';
 
-const getAllLists = async (): Promise<AuthApiData> => {
+interface ListData {
+  success?: boolean;
+  lists: List[];
+}
+
+const getAllLists = async (): Promise<ListData> => {
   const fetchOptions: FetchOptions = {
     method: 'GET',
     headers: { 'Content-Type': 'application/json' },
@@ -14,4 +20,22 @@ const getAllLists = async (): Promise<AuthApiData> => {
     }));
 };
 
-export { getAllLists };
+const addNewList = async (data: any): Promise<ListData> => {
+  const body = {
+    listName: data.name,
+  };
+
+  const fetchOptions: FetchOptions = {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify(body),
+  };
+  return await fetch(`/lists`, fetchOptions)
+    .then((res) => res.json())
+    .catch(() => ({
+      error: { message: 'Unable to connect to server. Please try again' },
+    }));
+};
+
+export { getAllLists, addNewList };

--- a/client/src/helpers/APICalls/lists.ts
+++ b/client/src/helpers/APICalls/lists.ts
@@ -1,4 +1,3 @@
-import { AuthApiData } from '../../interface/AuthApiData';
 import { FetchOptions } from '../../interface/FetchOptions';
 import { List } from '../../interface/List';
 

--- a/client/src/helpers/APICalls/product.ts
+++ b/client/src/helpers/APICalls/product.ts
@@ -2,13 +2,16 @@ import { FetchOptions } from '../../interface/FetchOptions';
 import { Product } from '../../interface/Product';
 
 const createProduct = async (product: Product, listID: string): Promise<Product> => {
+  const body = {
+    productDetails: product,
+  };
   const fetchOptions: FetchOptions = {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(product),
+    body: JSON.stringify(body),
     credentials: 'include',
   };
-  return await fetch(`/product/${listID}`, fetchOptions)
+  return await fetch(`/products/${listID}`, fetchOptions)
     .then((res) => res.json())
     .catch(() => ({
       error: { message: 'Unable to connect to server. Please try again' },

--- a/client/src/interface/List.ts
+++ b/client/src/interface/List.ts
@@ -1,8 +1,9 @@
-import { Product } from "./Product";
+import { Product } from './Product';
 
 export interface List {
   _id: string;
   name: string;
   products: Product[];
-  userId: string;
+  userIds: string;
+  creator: string;
 }

--- a/client/src/interface/Product.ts
+++ b/client/src/interface/Product.ts
@@ -1,8 +1,8 @@
 export interface Product {
-  _id: string;
+  _id?: string;
   name: string;
-  description: string;
+  description?: string;
   url: string;
   price: number;
-  pictureUrl: string;
+  pictureUrl?: string;
 }

--- a/client/src/pages/Dashboard/AddLinkForm/AddLinkForm.tsx
+++ b/client/src/pages/Dashboard/AddLinkForm/AddLinkForm.tsx
@@ -8,13 +8,35 @@ import FormControl from '@material-ui/core/FormControl';
 import InputLabel from '@material-ui/core/InputLabel';
 import Select from '@material-ui/core/Select';
 import MenuItem from '@material-ui/core/MenuItem';
+import { List } from '../../../interface/List';
+import { createProduct } from '../../../helpers/APICalls/product';
+import { Product } from '../../../interface/Product';
+interface Props {
+  listData: List[];
+  updateLists: () => Promise<void>;
+}
 
-export default function Dashboard(): JSX.Element {
+export default function AddLinkForm({ listData, updateLists }: Props): JSX.Element {
   const classes = useStyles();
-  const [age, setAge] = useState('');
 
-  const handleChange = (event: any) => {
-    setAge(event.target.value);
+  const [selectInput, setSelectInput] = useState(listData.length > 0 ? listData[0].name : '');
+  const [urlInput, setUrlInput] = useState('');
+
+  const handleSelectChange = (event: any) => {
+    setSelectInput(event.target.value);
+  };
+  const handleUrlInput = (event: any) => {
+    setUrlInput(event.target.value);
+  };
+
+  const handleSubmit = async () => {
+    const productDetails: Product = {
+      url: urlInput,
+      name: 'temp name',
+      price: 0,
+    };
+    await createProduct(productDetails, selectInput);
+    await updateLists();
   };
 
   return (
@@ -22,7 +44,7 @@ export default function Dashboard(): JSX.Element {
       <Typography variant="h5" className={classes.addLinkFormTitle} align={'center'}>
         Add new item:
       </Typography>
-      <form className={classes.addLinkForm} noValidate autoComplete="off">
+      <form onSubmit={handleSubmit} className={classes.addLinkForm} noValidate autoComplete="off">
         <Grid container>
           <TextField
             id="standard-basic"
@@ -30,24 +52,28 @@ export default function Dashboard(): JSX.Element {
             variant="standard"
             className={classes.urlFormInput}
             InputProps={{ disableUnderline: true }}
+            value={urlInput}
+            onChange={handleUrlInput}
           />
           <FormControl variant="standard" className={classes.selectField}>
             <InputLabel id="list-select-field">Select list</InputLabel>
             <Select
               labelId="list-select-field"
               id="demo-simple-select-filled"
-              value={age}
-              onChange={handleChange}
+              value={selectInput}
+              onChange={handleSelectChange}
               disableUnderline={true}
             >
-              <MenuItem value="">
-                <em>None</em>
-              </MenuItem>
-              <MenuItem value={'Shoes'}>Shoes</MenuItem>
-              <MenuItem value={'Tech'}>Tech</MenuItem>
+              {listData.map((list: List) => {
+                return (
+                  <MenuItem key={list.name} value={list._id}>
+                    {list.name}
+                  </MenuItem>
+                );
+              })}
             </Select>
           </FormControl>
-          <Button className={classes.formButton} color="secondary" variant="contained">
+          <Button onClick={handleSubmit} className={classes.formButton} color="secondary" variant="contained">
             Add
           </Button>
         </Grid>

--- a/client/src/pages/Dashboard/AddLinkForm/useStyles.ts
+++ b/client/src/pages/Dashboard/AddLinkForm/useStyles.ts
@@ -17,7 +17,7 @@ const useStyles = makeStyles((theme) => ({
   },
   urlFormInput: {
     flexGrow: 5.6,
-    padding: '0rem 0 0.55rem 0',
+    padding: '0rem 0.5rem 0.55rem 0',
   },
   formButton: {
     flexGrow: 2,

--- a/client/src/pages/Dashboard/Dashboard.tsx
+++ b/client/src/pages/Dashboard/Dashboard.tsx
@@ -9,7 +9,7 @@ import { useHistory } from 'react-router-dom';
 import ChatSideBanner from '../../components/ChatSideBanner/ChatSideBanner';
 import { useEffect, useState } from 'react';
 import AddProduct from '../../components/AddProduct/AddProduct';
-import { Button } from '@material-ui/core';
+import { Button, Modal } from '@material-ui/core';
 
 import Typography from '@material-ui/core/Typography';
 import Card from '@material-ui/core/Card';
@@ -25,6 +25,11 @@ import NavBar from '../../components/NavBar/NavBar';
 import AddLinkForm from './AddLinkForm/AddLinkForm';
 import ShoppingListCard from './ShoppingListCard/ShoppingListCard';
 
+import AddList from '../../components/AddList/AddList';
+
+import { List } from '../../interface/List';
+import { getAllLists } from '../../helpers/APICalls/lists';
+
 export default function Dashboard(): JSX.Element {
   const classes = useStyles();
 
@@ -35,12 +40,16 @@ export default function Dashboard(): JSX.Element {
 
   const [showAddProductModal, setShowAddProductModal] = useState(false);
 
+  const [addListModalOpen, setAddListModalOpen] = useState(false);
+  const [lists, setLists] = useState<List[]>([]);
+
   const openAddProductModal = () => {
     setShowAddProductModal(true);
   };
 
   useEffect(() => {
     initSocket();
+    getListsData();
   }, [initSocket]);
 
   if (loggedInUser === undefined) return <CircularProgress />;
@@ -50,13 +59,27 @@ export default function Dashboard(): JSX.Element {
     return <CircularProgress />;
   }
 
+  const getListsData = async () => {
+    getAllLists().then((data) => {
+      setLists(data.lists);
+    });
+  };
+
+  const handleModalClose = () => {
+    setAddListModalOpen(false);
+    getListsData(); // update lists
+  };
+  const handleModalOpen = () => {
+    setAddListModalOpen(true);
+  };
+
   return (
     <Grid container component="main" className={`${classes.root} ${classes.dashboard}`}>
       <CssBaseline />
       <NavBar />
 
       <Grid className={classes.pageContent} md={11} lg={10} xl={9}>
-        <AddLinkForm />
+        <AddLinkForm listData={lists} updateLists={getListsData} />
 
         <Grid className={classes.shoppingListsContentArea}>
           <Typography variant="h5" align={'left'} className={classes.shoppingListsTitle}>
@@ -71,14 +94,21 @@ export default function Dashboard(): JSX.Element {
             alignItems="flex-start"
             spacing={2}
           >
-            <ShoppingListCard title="Clothes" itemCount={34} image={ClothesImage} />
-            <ShoppingListCard title="Furniture" itemCount={12} image={FurnitureImage} />
-            <ShoppingListCard title="Luxury" itemCount={8} image={LuxuryImage} />
+            {lists.map((list: List) => {
+              return (
+                <ShoppingListCard
+                  key={list._id}
+                  title={list.name}
+                  itemCount={list.products.length}
+                  image={ClothesImage}
+                />
+              );
+            })}
 
             {/* Add new list button */}
             <Grid item>
               <Card className={classes.shoppingListCard}>
-                <CardActionArea className={classes.shoppingListButton}>
+                <CardActionArea className={classes.shoppingListButton} onClick={() => handleModalOpen()}>
                   <Grid>
                     <AddIcon color="secondary" className={classes.addNewListIcon} />
                   </Grid>
@@ -97,6 +127,9 @@ export default function Dashboard(): JSX.Element {
         <Button onClick={openAddProductModal}>Add Product</Button>
         <AddProduct showAddProductModal={showAddProductModal} setShowAddProductModal={setShowAddProductModal} />
       </Grid>
+      <Modal open={addListModalOpen} onClose={handleModalClose}>
+        <AddList onClose={handleModalClose} />
+      </Modal>
     </Grid>
   );
 }

--- a/client/src/pages/Dashboard/Dashboard.tsx
+++ b/client/src/pages/Dashboard/Dashboard.tsx
@@ -29,9 +29,11 @@ import AddList from '../../components/AddList/AddList';
 
 import { List } from '../../interface/List';
 import { getAllLists } from '../../helpers/APICalls/lists';
+import { useSnackBar } from '../../context/useSnackbarContext';
 
 export default function Dashboard(): JSX.Element {
   const classes = useStyles();
+  const { updateSnackBarMessage } = useSnackBar();
 
   const { loggedInUser } = useAuth();
   const { initSocket } = useSocket();
@@ -60,9 +62,12 @@ export default function Dashboard(): JSX.Element {
   }
 
   const getListsData = async () => {
-    getAllLists().then((data) => {
-      setLists(data.lists);
-    });
+    const result = await getAllLists();
+    if (result.success) {
+      setLists(result.lists);
+    } else {
+      updateSnackBarMessage('Failed to update lists');
+    }
   };
 
   const handleModalClose = () => {


### PR DESCRIPTION
## Note: https://github.com/hatchways/team-athens/pull/82 replaces this PR

### What this PR does (required):
- FE for adding new lists and product on the home page
- 

### Screenshots / Videos (required):
![Screenshot 2021-06-21 070418](https://user-images.githubusercontent.com/13183518/122752445-f9860200-d25e-11eb-9a8c-1d82de17c7a4.png)


### Any information needed to test this feature (required):
- log in
- when adding a new list, refresh
- when adding a new product, check the number of items under the list u added to

### Any issues with the current functionality (optional):
- New products are made empty, assuming that scraping will happen afterwards
- Lists don't rerender after a new list is added
